### PR TITLE
Fix unconditional printing in Lua script

### DIFF
--- a/Bullshit.lua
+++ b/Bullshit.lua
@@ -1,5 +1,8 @@
-if "bullshit"
-  then
-  print("bullshit")
+-- Print "bullshit" only when the first command line argument is the
+-- string "bullshit".  This avoids printing unconditionally.
+
+if arg and arg[1] == "bullshit" then
+    print("bullshit")
 else
+    print("no bullshit")
 end


### PR DESCRIPTION
## Summary
- fix unconditional printing in `Bullshit.lua`
- use command line argument to control output

## Testing
- `lua Bullshit.lua` *(fails: `lua` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2711e820832db588902bff9e6255